### PR TITLE
spport for multiple executables per run

### DIFF
--- a/gfe_integration_tests/test_rte/test_rte_during_run.py
+++ b/gfe_integration_tests/test_rte/test_rte_during_run.py
@@ -2,7 +2,7 @@ import os
 import pytest
 
 import spinnaker_graph_front_end as s
-from spinn_front_end_common.utilities.utility_objs import ExecutableStartType
+from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from gfe_integration_tests.test_rte.test_run_vertex import TestRunVertex
 from spinnman.exceptions import SpinnmanException
 
@@ -11,6 +11,6 @@ def test_rte_during_run():
     s.setup(model_binary_folder=os.path.dirname(__file__))
     s.add_machine_vertex_instance(TestRunVertex(
         "test_rte_during_run.aplx",
-        ExecutableStartType.USES_SIMULATION_INTERFACE))
+        ExecutableType.USES_SIMULATION_INTERFACE))
     with pytest.raises(SpinnmanException):
         s.run(1000)

--- a/gfe_integration_tests/test_rte/test_rte_during_run_forever.py
+++ b/gfe_integration_tests/test_rte/test_rte_during_run_forever.py
@@ -3,7 +3,7 @@ from time import sleep
 import pytest
 
 import spinnaker_graph_front_end as s
-from spinn_front_end_common.utilities.utility_objs import ExecutableStartType
+from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from gfe_integration_tests.test_rte.test_run_vertex import TestRunVertex
 from spinn_front_end_common.utilities.exceptions \
     import ExecutableFailedToStopException
@@ -13,7 +13,7 @@ def test_rte_during_run_forever():
     s.setup(model_binary_folder=os.path.dirname(__file__))
     s.add_machine_vertex_instance(TestRunVertex(
         "test_rte_during_run.aplx",
-        ExecutableStartType.USES_SIMULATION_INTERFACE))
+        ExecutableType.USES_SIMULATION_INTERFACE))
     s.run(None)
     sleep(2.0)
     with pytest.raises(ExecutableFailedToStopException):

--- a/gfe_integration_tests/test_rte/test_rte_start.py
+++ b/gfe_integration_tests/test_rte/test_rte_start.py
@@ -2,7 +2,7 @@ import os
 import pytest
 
 import spinnaker_graph_front_end as s
-from spinn_front_end_common.utilities.utility_objs import ExecutableStartType
+from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from gfe_integration_tests.test_rte.test_run_vertex import TestRunVertex
 from spinnman.exceptions import SpinnmanException
 
@@ -12,6 +12,6 @@ def test_rte_at_start():
     s.add_machine_vertex_instance(
         TestRunVertex(
             "test_rte_start.aplx",
-            ExecutableStartType.USES_SIMULATION_INTERFACE))
+            ExecutableType.USES_SIMULATION_INTERFACE))
     with pytest.raises(SpinnmanException):
         s.run(1000)

--- a/gfe_integration_tests/test_rte/test_run_too_long.py
+++ b/gfe_integration_tests/test_rte/test_run_too_long.py
@@ -2,7 +2,7 @@ import os
 import pytest
 
 import spinnaker_graph_front_end as s
-from spinn_front_end_common.utilities.utility_objs import ExecutableStartType
+from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from gfe_integration_tests.test_rte.test_run_vertex import TestRunVertex
 from spinnman.exceptions import SpinnmanTimeoutException
 
@@ -11,6 +11,6 @@ def test_run_too_long():
     s.setup(model_binary_folder=os.path.dirname(__file__))
     s.add_machine_vertex_instance(TestRunVertex(
         "test_run_too_long.aplx",
-        ExecutableStartType.USES_SIMULATION_INTERFACE))
+        ExecutableType.USES_SIMULATION_INTERFACE))
     with pytest.raises(SpinnmanTimeoutException):
         s.run(1000)

--- a/spinnaker_graph_front_end/examples/Conways/partitioned_example_a_no_vis_no_buffer/conways_basic_cell.py
+++ b/spinnaker_graph_front_end/examples/Conways/partitioned_example_a_no_vis_no_buffer/conways_basic_cell.py
@@ -15,7 +15,7 @@ from spinn_front_end_common.interface.simulation import simulation_utilities
 from spinn_front_end_common.abstract_models.impl \
     import MachineDataSpecableVertex
 from spinn_front_end_common.abstract_models import AbstractHasAssociatedBinary
-from spinn_front_end_common.utilities.utility_objs import ExecutableStartType
+from spinn_front_end_common.utilities.utility_objs import ExecutableType
 
 
 # general imports
@@ -57,7 +57,7 @@ class ConwayBasicCell(
 
     @overrides(AbstractHasAssociatedBinary.get_binary_start_type)
     def get_binary_start_type(self):
-        return ExecutableStartType.USES_SIMULATION_INTERFACE
+        return ExecutableType.USES_SIMULATION_INTERFACE
 
     @inject_items({"n_machine_time_steps": "TotalMachineTimeSteps"})
     @overrides(

--- a/spinnaker_graph_front_end/examples/Conways/partitioned_example_b_no_vis_buffer/conways_basic_cell.py
+++ b/spinnaker_graph_front_end/examples/Conways/partitioned_example_b_no_vis_buffer/conways_basic_cell.py
@@ -17,7 +17,7 @@ from spinn_front_end_common.interface.buffer_management \
 from spinn_front_end_common.abstract_models.impl \
     import MachineDataSpecableVertex
 from spinn_front_end_common.abstract_models import AbstractHasAssociatedBinary
-from spinn_front_end_common.utilities.utility_objs import ExecutableStartType
+from spinn_front_end_common.utilities.utility_objs import ExecutableType
 
 # general imports
 from enum import Enum
@@ -69,7 +69,7 @@ class ConwayBasicCell(
 
     @overrides(AbstractHasAssociatedBinary.get_binary_start_type)
     def get_binary_start_type(self):
-        return ExecutableStartType.USES_SIMULATION_INTERFACE
+        return ExecutableType.USES_SIMULATION_INTERFACE
 
     @overrides(MachineDataSpecableVertex.generate_machine_data_specification)
     def generate_machine_data_specification(

--- a/spinnaker_graph_front_end/examples/hello_world/hello_world_vertex.py
+++ b/spinnaker_graph_front_end/examples/hello_world/hello_world_vertex.py
@@ -13,7 +13,7 @@ from spinn_front_end_common.interface.buffer_management.buffer_models\
     import AbstractReceiveBuffersToHost
 from spinn_front_end_common.interface.buffer_management\
     import recording_utilities
-from spinn_front_end_common.utilities.utility_objs import ExecutableStartType
+from spinn_front_end_common.utilities.utility_objs import ExecutableType
 
 from enum import Enum
 import logging
@@ -70,7 +70,7 @@ class HelloWorldVertex(
 
     @overrides(AbstractHasAssociatedBinary.get_binary_start_type)
     def get_binary_start_type(self):
-        return ExecutableStartType.USES_SIMULATION_INTERFACE
+        return ExecutableType.USES_SIMULATION_INTERFACE
 
     @overrides(MachineDataSpecableVertex.generate_machine_data_specification)
     def generate_machine_data_specification(

--- a/spinnaker_graph_front_end/examples/template/vertex.py
+++ b/spinnaker_graph_front_end/examples/template/vertex.py
@@ -9,7 +9,7 @@ from spinn_front_end_common.utilities import constants, helpful_functions
 from spinn_front_end_common.interface.buffer_management \
     import recording_utilities
 from spinn_front_end_common.interface.simulation import simulation_utilities
-from spinn_front_end_common.utilities.utility_objs import ExecutableStartType
+from spinn_front_end_common.utilities.utility_objs import ExecutableType
 
 from pacman.model.decorators import overrides
 from pacman.model.graphs.machine import MachineVertex
@@ -84,7 +84,7 @@ class Vertex(
 
     @overrides(AbstractHasAssociatedBinary.get_binary_start_type)
     def get_binary_start_type(self):
-        return ExecutableStartType.USES_SIMULATION_INTERFACE
+        return ExecutableType.USES_SIMULATION_INTERFACE
 
     @overrides(MachineDataSpecableVertex.generate_machine_data_specification)
     def generate_machine_data_specification(


### PR DESCRIPTION
supports the ability to have multiple executableTypes running on the same application. Mainly used for reinjector and extra monitor support (which are to follow pull requests in future).

this depends upon a FEC pull request
SpiNNakerManchester/SpiNNFrontEndCommon#214