### PR TITLE
It's pronounced time_scale_factor, not timescale_factor

### DIFF
--- a/spinnaker_graph_front_end/__init__.py
+++ b/spinnaker_graph_front_end/__init__.py
@@ -39,7 +39,7 @@ __all__ = ['LivePacketGather', 'ReverseIpTagMultiCastSource', 'MachineEdge',
            'add_machine_edge_instance', 'add_socket_address', 'get_txrx',
            'has_ran', 'machine_time_step',
            'get_number_of_available_cores_on_machine', 'no_machine_time_steps',
-           'timescale_factor', 'machine_graph', 'application_graph',
+           'time_scale_factor', 'machine_graph', 'application_graph',
            'routing_infos', 'placements', 'transceiver', 'graph_mapper',
            'buffer_manager', 'machine', 'is_allocated_machine']
 
@@ -353,7 +353,7 @@ def no_machine_time_steps():
     return _sim().no_machine_time_steps
 
 
-def timescale_factor():
+def time_scale_factor():
     return _sim().time_scale_factor
 
 


### PR DESCRIPTION
See https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/539

Technically this is an API change, but let's not add subtle spelling differences all over the place that confuse. And I don't think much user code actually cares about this either. The benefit to us should exceed the amount of user pain...
