### PR TITLE
removed unused variable 'buffer_manager' from Conway's example not using the 'buffer_manager' for data extraction

### DIFF
--- a/spinnaker_graph_front_end/examples/Conways/partitioned_example_a_no_vis_no_buffer/conways_partitioned.py
+++ b/spinnaker_graph_front_end/examples/Conways/partitioned_example_a_no_vis_no_buffer/conways_partitioned.py
@@ -92,7 +92,6 @@ recorded_data = dict()
 
 # get the data per vertex
 if not front_end.use_virtual_machine():
-    buffer_manager = front_end.buffer_manager()
     for x in range(0, MAX_X_SIZE_OF_FABRIC):
         for y in range(0, MAX_Y_SIZE_OF_FABRIC):
             recorded_data[x, y] = vertices[x][y].get_data(


### PR DESCRIPTION
fixes #

calling this a fix is kind of an exaggeration... But I was looking through the example `Conways/partitioned_example_a_no_vis_no_buffer` which clearly should not use the `buffer_manager` and encountered a `buffer_manager` which made me stop just to realize it is an unused variable.

modules this fix is associated with #

Things to do in this repository
===============================
- [ ] documented code changes. 
- [ ] updated bug/feature flags.
- [ ] updated github developers associated with.
- [ ] updated schedule for when this pull request should be completed.

Tests to verify that the change hasn't affected existing functionality
----------------------------------------------------------------------
- [ ] GFE test heat demo code.
- [ ] GFE test hello world. 
- [ ] GFE test ray tracer. 
- [x] GFE test conways partitioned batch of examples.

- [ ] test with live extraction (is being ignored at date as auto_pause-and_resume works).

Associated documentation changes
--------------------------------
 - [ ] changed workshop slides accordingly.
 - [ ] changed gitio pages accordingly.
 
Verification of changes from team members
-----------------------------------------
 - [ ] verified team member 1.
 - [ ] verified team member 2.
 
Checks Against Other Supported Systems
======================================
If the code includes changes outside the Graph Front End, please ensure that these test cases also pass:
- [ ] spynnaker test basic reads for v (use synfire).
- [ ] spynnaker test basic read for gsyn (use synfire).
- [ ] spynnaker test basic read for spikes (use synfire).
- [ ] spynnaker test multiple reads and writes (use synfire).
- [ ] spynnaker test no reads and writes (use synfire).
- [ ] spynnaker test ssa recording (use synfire).
- [ ] spynnaker test poission recording (used pynn brunnel).
- [ ] spynnaker test poission no recording (use pynn brunnel).
- [ ] spynnaker test auto pause and resume battery of tests.
- [ ] spynnaker test va benchmark from spynnaker.
- [ ] spynnaker test with microcircuit 10 % model.
- [ ] spynnaker test with microcircuit 100 % model.

- [ ] test reload (use synfire) (has been disabled till a plan of action on it is decided).
