### PR TITLE
Stop old-style function and unused parameter compiler warnings

### DIFF
--- a/spinnaker_graph_front_end/examples/hello_world_untimed/src/hello_world.c
+++ b/spinnaker_graph_front_end/examples/hello_world_untimed/src/hello_world.c
@@ -107,18 +107,18 @@ static void resume_callback(void) {
 }
 
 
-static void exit_callback() {
+static void exit_callback(void) {
     if (recording_flags) {
         recording_finalise();
     }
 }
 
-static void start_callback() {
+static void start_callback(void) {
     log_info("Scheduling callback from start");
     spin1_schedule_callback(run, 0, 0, 1);
 }
 
-static bool initialize() {
+static bool initialize(void) {
     // Get the address this core's DTCM data starts at from SRAM
     data_specification_metadata_t *data = data_specification_get_data_address();
 

--- a/spinnaker_graph_front_end/examples/template/src/c_template_vertex.c
+++ b/spinnaker_graph_front_end/examples/template/src/c_template_vertex.c
@@ -77,6 +77,7 @@ static uint32_t my_key;
 //! \param[in] payload is the payload of packet [none].
 //! \return None
 void receive_data_no_payload(uint key, uint payload) {
+    use(key);
     use(payload);
 
     // TODO: Handle a received multicast packet without a payload
@@ -87,6 +88,8 @@ void receive_data_no_payload(uint key, uint payload) {
 //! \param[in] payload is the payload of packet.
 //! \return None
 void receive_data_payload(uint key, uint payload) {
+    use(key);
+    use(payload);
 
     // TODO: Handle a received multicast packet with a payload
 }
@@ -102,6 +105,8 @@ void receive_data_payload(uint key, uint payload) {
 //! \param[in] time the tracked timer.
 //! \return None
 static void do_update(uint ticks, uint32_t time) {
+    use(ticks);
+    use(time);
 
     // TODO: Handle a timer tick
 


### PR DESCRIPTION
A few bits of code were still giving compiler warnings for old-style functions and unused parameters, this fixes those places.