### PR TITLE
Use the right token for coveralls

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -61,7 +61,7 @@ jobs:
         tests: unittests
         coverage: ${{ matrix.python-version == 3.8 }}
         cover-packages: spinnaker_graph_front_end
-        coveralls-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        coveralls-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Lint with flake8
       run: flake8 spinnaker_graph_front_end unittests gfe_examples


### PR DESCRIPTION
I was wondering why coverage uploading wasn't working. Turns out I was doing a few things subtly wrong, one of which is that it needs a different token…