### PR TITLE
nuked "unrecognized arguments: -q"

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -429,5 +429,5 @@ for fl in os.listdir("."):
         os.remove(fl)
 os.chdir("../..")  # WARNING! RELATIVE FILENAMES CHANGE MEANING HERE!
 apidoc.main([
-    '-q', '-o', _output_dir, _package_base,
+    '-o', _output_dir, _package_base,
     *filtered_files(_package_base, _unfiltered_files)])


### PR DESCRIPTION
fixes #

modules this fix is associated with #

Things to do in this repository
===============================
- [ ] documented code changes. 
- [ ] updated bug/feature flags.
- [ ] updated github developers associated with.
- [ ] updated schedule for when this pull request should be completed.

Tests to verify that the change hasn't affected existing functionality
----------------------------------------------------------------------
- [ ] GFE test heat demo code.
- [ ] GFE test hello world. 
- [ ] GFE test ray tracer. 
- [ ] GFE test conways partitioned batch of examples.

- [ ] test with live extraction (is being ignored at date as auto_pause-and_resume works).

Associated documentation changes
--------------------------------
 - [ ] changed workshop slides accordingly.
 - [ ] changed gitio pages accordingly.
 
Verification of changes from team members
-----------------------------------------
 - [ ] verified team member 1.
 - [ ] verified team member 2.
 
Checks Against Other Supported Systems
======================================
If the code includes changes outside the Graph Front End, please ensure that these test cases also pass:
- [ ] spynnaker test basic reads for v (use synfire).
- [ ] spynnaker test basic read for gsyn (use synfire).
- [ ] spynnaker test basic read for spikes (use synfire).
- [ ] spynnaker test multiple reads and writes (use synfire).
- [ ] spynnaker test no reads and writes (use synfire).
- [ ] spynnaker test ssa recording (use synfire).
- [ ] spynnaker test poission recording (used pynn brunnel).
- [ ] spynnaker test poission no recording (use pynn brunnel).
- [ ] spynnaker test auto pause and resume battery of tests.
- [ ] spynnaker test va benchmark from spynnaker.
- [ ] spynnaker test with microcircuit 10 % model.
- [ ] spynnaker test with microcircuit 100 % model.

- [ ] test reload (use synfire) (has been disabled till a plan of action on it is decided).
