### PR TITLE
Unittest setup

### DIFF
--- a/gfe_integration_tests/test_extra_monitor/test_extra_monitor.py
+++ b/gfe_integration_tests/test_extra_monitor/test_extra_monitor.py
@@ -16,7 +16,6 @@
 import time
 import os
 from data_specification.utility_calls import get_region_base_address_offset
-from spinn_front_end_common.utilities import globals_variables
 from spinn_front_end_common.utilities.helpful_functions import n_word_struct
 import spinnaker_graph_front_end as sim
 from gfe_integration_tests.test_extra_monitor.sdram_writer import (
@@ -102,7 +101,6 @@ class TestExtraMonitors(BaseTestCase):
         mbs = _TRANSFER_SIZE_MEGABYTES
 
         # setup system
-        globals_variables.unset_simulator()
         sim.setup(model_binary_folder=os.path.dirname(__file__),
                   n_chips_required=2)
 

--- a/gfe_integration_tests/test_hello_world.py
+++ b/gfe_integration_tests/test_hello_world.py
@@ -20,9 +20,6 @@ from spinnaker_testbase import ScriptChecker
 
 class TestHelloWorld(ScriptChecker):
 
-    def setUp(self):
-        globals_variables.unset_simulator()
-
     def test_hello_world(self):
         with LogCapture("hello_world") as lc:
             self.check_script(

--- a/gfe_integration_tests/test_hello_world_untimed.py
+++ b/gfe_integration_tests/test_hello_world_untimed.py
@@ -14,16 +14,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from testfixtures import LogCapture
-from spinn_front_end_common.utilities import globals_variables
 from spinnaker_testbase import ScriptChecker
 
 
 class TestHelloWorldUntimed(ScriptChecker):
 
-    def setUp(self):
-        globals_variables.unset_simulator()
-
-    def test_hello_world_untimed(self):
+   def test_hello_world_untimed(self):
         with LogCapture("hello_world") as lc:
             self.check_script(
                 "gfe_examples/hello_world_untimed/hello_world.py")

--- a/gfe_integration_tests/test_rte/test_rte_during_run.py
+++ b/gfe_integration_tests/test_rte/test_rte_during_run.py
@@ -17,14 +17,12 @@ import os
 import traceback
 import pytest
 from spinn_front_end_common.utilities.utility_objs import ExecutableType
-from spinn_front_end_common.utilities import globals_variables
 from spinnman.exceptions import SpinnmanException
 import spinnaker_graph_front_end as s
 from gfe_integration_tests.test_rte.run_vertex import RunVertex
 
 
 def test_rte_during_run():
-    globals_variables.unset_simulator()
     s.setup(model_binary_folder=os.path.dirname(__file__))
     s.add_machine_vertex_instance(RunVertex(
         "test_rte_during_run.aplx",

--- a/gfe_integration_tests/test_rte/test_rte_during_run_forever.py
+++ b/gfe_integration_tests/test_rte/test_rte_during_run_forever.py
@@ -19,14 +19,12 @@ from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.utilities.exceptions import (
     ExecutableFailedToStopException)
 from spinn_front_end_common.utilities.database import DatabaseConnection
-from spinn_front_end_common.utilities import globals_variables
 import spinnaker_graph_front_end as s
 from gfe_integration_tests.test_rte.run_vertex import RunVertex
 import pytest
 
 
 def test_rte_during_run_forever():
-    globals_variables.unset_simulator()
 
     def start():
         sleep(3.0)

--- a/gfe_integration_tests/test_rte/test_rte_start.py
+++ b/gfe_integration_tests/test_rte/test_rte_start.py
@@ -16,14 +16,12 @@
 import os
 import pytest
 from spinn_front_end_common.utilities.utility_objs import ExecutableType
-from spinn_front_end_common.utilities import globals_variables
 from spinnman.exceptions import SpinnmanException
 import spinnaker_graph_front_end as s
 from gfe_integration_tests.test_rte.run_vertex import RunVertex
 
 
 def test_rte_at_start():
-    globals_variables.unset_simulator()
     s.setup(model_binary_folder=os.path.dirname(__file__))
     s.add_machine_vertex_instance(
         RunVertex(

--- a/gfe_integration_tests/test_rte/test_run_too_long.py
+++ b/gfe_integration_tests/test_rte/test_run_too_long.py
@@ -23,7 +23,6 @@ from gfe_integration_tests.test_rte.run_vertex import RunVertex
 
 
 def test_run_too_long():
-    globals_variables.unset_simulator()
     s.setup(model_binary_folder=os.path.dirname(__file__))
     s.add_machine_vertex_instance(RunVertex(
         "test_run_too_long.aplx",

--- a/spinnaker_graph_front_end/config_setup.py
+++ b/spinnaker_graph_front_end/config_setup.py
@@ -18,7 +18,8 @@ from spinn_utilities.config_holder import (
     clear_cfg_files, set_cfg_files)
 from spinn_front_end_common.interface.config_setup import (
     add_default_cfg, add_spinnaker_cfg)
-from spinn_front_end_common.utilities.globals_variables import unset_simulator
+from spinn_front_end_common.utilities.globals_variables import (
+    setup_for_unittest)
 
 #: The name of the configuration file
 CONFIG_FILE_NAME = "spiNNakerGraphFrontEnd.cfg"
@@ -53,7 +54,7 @@ def unittest_setup():
          that do not call sim.setup
 
     """
-    unset_simulator()
+    setup_for_unittest()
     clear_cfg_files(True)
     add_spinnaker_cfg()  # This add its dependencies too
     add_default_cfg(os.path.join(os.path.dirname(__file__), CONFIG_FILE_NAME))

--- a/spinnaker_graph_front_end/config_setup.py
+++ b/spinnaker_graph_front_end/config_setup.py
@@ -57,4 +57,3 @@ def unittest_setup():
     clear_cfg_files(True)
     add_spinnaker_cfg()  # This add its dependencies too
     add_default_cfg(os.path.join(os.path.dirname(__file__), CONFIG_FILE_NAME))
-

--- a/spinnaker_graph_front_end/config_setup.py
+++ b/spinnaker_graph_front_end/config_setup.py
@@ -16,26 +16,45 @@
 import os
 from spinn_utilities.config_holder import (
     clear_cfg_files, set_cfg_files)
-from spinn_front_end_common.interface.config_setup import add_spinnaker_cfg
+from spinn_front_end_common.interface.config_setup import (
+    add_default_cfg, add_spinnaker_cfg)
+from spinn_front_end_common.utilities.globals_variables import unset_simulator
 
 #: The name of the configuration file
 CONFIG_FILE_NAME = "spiNNakerGraphFrontEnd.cfg"
 
 
-def reset_configs():
+def setup_configs():
     """
-    Resets the configs so only the local default config is included.
+    Sets up the configs including the users cfg file
+
+    Clears out any previous read configs but does not load the new configs
+    so a warning is generated if a config is used before setup is called.
 
     """
-    clear_cfg_files()
-    add_gfe_cfg()
-
-
-def add_gfe_cfg():
-    """
-    Add the local cfg and all dependent cfg files.
-    """
+    clear_cfg_files(False)
     add_spinnaker_cfg()  # This add its dependencies too
     set_cfg_files(
         configfile=CONFIG_FILE_NAME,
         default=os.path.join(os.path.dirname(__file__), CONFIG_FILE_NAME))
+
+
+def unittest_setup():
+    """
+    Does all the steps that may be required before a unittest
+
+    Resets the configs so only the local default configs are included.
+    The user cfg is NOT included!
+
+    Unsets any previous simulators and tempdirs
+
+    .. note::
+         This file should only be called from Spynnaker tests
+         that do not call sim.setup
+
+    """
+    unset_simulator()
+    clear_cfg_files(True)
+    add_spinnaker_cfg()  # This add its dependencies too
+    add_default_cfg(os.path.join(os.path.dirname(__file__), CONFIG_FILE_NAME))
+

--- a/spinnaker_graph_front_end/spinnaker.py
+++ b/spinnaker_graph_front_end/spinnaker.py
@@ -18,7 +18,7 @@ from spinn_utilities.config_holder import get_config_str
 from spinn_utilities.log import FormatAdapter
 from spinn_front_end_common.interface.abstract_spinnaker_base import (
     AbstractSpinnakerBase)
-from spinnaker_graph_front_end.config_setup import reset_configs
+from spinnaker_graph_front_end.config_setup import setup_configs
 from ._version import __version__ as version
 
 logger = FormatAdapter(logging.getLogger(__name__))
@@ -81,6 +81,9 @@ class SpiNNaker(AbstractSpinnakerBase):
             Where to look for algorithm descriptors
         """
         # DSG algorithm store for user defined algorithms
+
+        # At import time change the default FailedState
+        setup_configs()
         self._user_dsg_algorithm = dsg_algorithm
 
         front_end_versions = [("SpiNNakerGraphFrontEnd", version)]
@@ -140,7 +143,3 @@ class SpiNNaker(AbstractSpinnakerBase):
     def __repr__(self):
         return "SpiNNaker Graph Front End object for machine {}".format(
             self._hostname)
-
-
-# At import time change the default FailedState
-reset_configs()

--- a/unittests/test_cfg_checker.py
+++ b/unittests/test_cfg_checker.py
@@ -16,14 +16,13 @@
 import os
 import unittest
 from spinn_utilities.config_holder import run_config_checks
-from spinnaker_graph_front_end.config_setup import reset_configs
+from spinnaker_graph_front_end.config_setup import unittest_setup
 
 
 class TestCfgChecker(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        reset_configs()
+    def setUp(self):
+        unittest_setup()
 
     def test_config_checks(self):
         unittests = os.path.dirname(__file__)

--- a/unittests/test_import_all.py
+++ b/unittests/test_import_all.py
@@ -20,6 +20,9 @@ _CI = os.environ.get('CONTINUOUS_INTEGRATION', 'false').lower()
 
 
 class ImportAllModule(unittest.TestCase):
+
+    # no unittest_setup to check all imports work without it
+
     def test_import_all(self):
         package_loader.load_module("spinnaker_graph_front_end",
                                    remove_pyc_files=(_CI != 'true'))

--- a/unittests/test_version.py
+++ b/unittests/test_version.py
@@ -27,6 +27,8 @@ class Test(unittest.TestCase):
     """ Tests for the component version comparison
     """
 
+    # no unittest_setup to check version without it
+
     def test_compare_versions(self):
         spinn_utilities_parts = spinn_utilities.__version__.split('.')
         spinn_machine_parts = spinn_machine.__version__.split('.')


### PR DESCRIPTION
globals_variables.unset_simulator() was mainly needed if a previous simulator shut down bad.

We now allow setup() to do the cleanup so it is no longer needed