### PR TITLE
used a fixed machine where possible

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Create a configuration file
       uses: ./support/actions/configure-spynnaker
       with:
-        board-address: spinn-4.cs.man.ac.uk
+        virtual: true
     - run: mv ~/.spynnaker.cfg ~/.spiNNakerGraphFrontEnd.cfg
     - name: Test with pytest
       uses: ./support/actions/pytest

--- a/spinnaker_graph_front_end/spinnaker.py
+++ b/spinnaker_graph_front_end/spinnaker.py
@@ -58,12 +58,10 @@ class SpiNNaker(AbstractSpinnakerBase):
         # At import time change the default FailedState
         setup_configs()
 
-        super().__init__()
+        super().__init__(n_boards_required, n_chips_required)
 
         with ProvenanceWriter() as db:
             db.insert_version("SpiNNakerGraphFrontEnd", version)
-
-        self._data_writer.set_n_required(n_boards_required, n_chips_required)
 
         self._data_writer.set_up_timings(
             machine_time_step, time_scale_factor, 1)


### PR DESCRIPTION
Part of https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/969

Note: the github actions cfg has been changed from an invalid one pointing at spinn-4.cs.man.ac.uk to a virtual machine

There is currently not slowdown of unittest as there are no unittest that do sim.setup but not sim.run