### PR TITLE
ubuntu-lts-latest for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@
 
 version: 2
 build:
-  os: ubuntu-latest
+  os: ubuntu-lts-latest
   tools:
     python: "3.13"
 sphinx:


### PR DESCRIPTION
rror
Config validation error in build.os. Expected one of (ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, ubuntu-lts-latest), got type str (ubuntu-latest). Double check the type of the value. A string may be required (e.g. "3.10" instead of 3.10)